### PR TITLE
Moved `react-is` to peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "react-keyed-flatten-children",
       "version": "4.0.0",
       "license": "MIT",
-      "dependencies": {
-        "react-is": "^19.0.0"
-      },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/react": "^16.2.0",
@@ -22,13 +19,15 @@
         "jsdom-global": "^3.0.2",
         "prettier": "^2.8.8",
         "react": "^19.0.0",
+        "react-is": "^19.0.0",
         "tape": "^5.9.0",
         "tsup": "^7.2.0",
         "tsx": "^3.13.0",
         "typescript": "^5.0.4"
       },
       "peerDependencies": {
-        "react": ">=15.0.0"
+        "react": "^18.0.0 || ^19.0.0",
+        "react-is": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -2779,7 +2778,8 @@
     "node_modules/react-is": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
-      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
+      "dev": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -44,15 +44,14 @@
     "jsdom-global": "^3.0.2",
     "prettier": "^2.8.8",
     "react": "^19.0.0",
+    "react-is": "^19.0.0",
     "tape": "^5.9.0",
     "tsup": "^7.2.0",
     "tsx": "^3.13.0",
     "typescript": "^5.0.4"
   },
-  "dependencies": {
-    "react-is": "^19.0.0"
-  },
   "peerDependencies": {
-    "react": ">=19.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-is": "^18.0.0 || ^19.0.0"
   }
 }


### PR DESCRIPTION
### Overview
Moving `react-is` to `peerDependencies` gives this packages better support for a wider range of React versions. Consumers should ensure the version of `react-is` install is the same as their version of `react`. I'm not sure if we can enforce this somehow? This PR is a breaking change but it will resolve the following warning on the repo:

> ⚠️ As of v4.0.0, this library only supports React 19. If you're using React 18 or under, stay on the (still maintained) v3.2.0+.

I'm not entirely sure if we need to update any logic traversing the tree. I believe the tree structure is consistent between different versions of React.