### PR TITLE
Add BigInt support for React 19

### DIFF
--- a/index.spec.tsx
+++ b/index.spec.tsx
@@ -56,6 +56,44 @@ test("simple children", function (t) {
   );
 });
 
+test("bigint children", function (t) {
+  t.plan(4);
+
+  const { container } = render(
+    <Assert
+      assert={(result) => {
+        t.equal(result.length, 4, "array length");
+
+        t.equal(isElement(result[0]) && result[0].key, ".0", "0th element key");
+        t.equal(result[1], 10n, "1st bigint child");
+        t.equal(result[3], BigInt(20), "3rd BigInt() child");
+      }}
+    >
+      <span>one</span>
+      {10n}
+      <span>two</span>
+      {BigInt(20)}
+    </Assert>
+  );
+});
+
+test("bigint in nested fragments", function (t) {
+  t.plan(2);
+
+  const { container } = render(
+    <Assert
+      assert={(result) => {
+        t.equal(result.length, 1, "array length");
+        t.equal(result[0], 100n, "nested bigint preserved");
+      }}
+    >
+      <>
+        <>{100n}</>
+      </>
+    </Assert>
+  );
+});
+
 test("nested arrays and fragments with mixed content", function (t) {
   t.plan(2);
 

--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,11 @@ export default function flattenChildren(
               key: keys.concat(String(node.key)).join("."),
             })
           );
-        } else if (typeof node === "string" || typeof node === "number") {
+        } else if (
+          typeof node === "string" ||
+          typeof node === "number" ||
+          typeof node === "bigint"
+        ) {
           acc.push(node);
         }
       }


### PR DESCRIPTION
## Summary

- Adds `bigint` to the type check in `flattenChildren`, alongside `string` and `number`
- React 19 added native BigInt rendering support, but the library was silently filtering them out
- Adds test coverage for BigInt children (both literal syntax `10n` and `BigInt()`)

Fixes #28

## Test plan

- [x] Existing tests pass (28/28)
- [x] New BigInt tests pass
- [x] BigInt literals (`10n`) are preserved in output
- [x] `BigInt()` constructor values are preserved
- [x] BigInts in nested fragments are flattened correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)